### PR TITLE
Removed extra "reduce" statements.

### DIFF
--- a/Python/ml_metrics/quadratic_weighted_kappa.py
+++ b/Python/ml_metrics/quadratic_weighted_kappa.py
@@ -2,64 +2,64 @@
 
 import numpy
 
-def confusion_matrix(rater_a, rater_b,
-		 min_rating=None, max_rating=None):
+def confusion_matrix(rater_a, rater_b, min_rating=None, max_rating=None):
     """
     Returns the confusion matrix between rater's ratings
     """
-    assert(len(rater_a)==len(rater_b))
+    assert(len(rater_a) == len(rater_b))
     if min_rating is None:
-        min_rating = min(reduce(min, rater_a), reduce(min, rater_b))
+        min_rating = min(rater_a + rater_b)
     if max_rating is None:
-        max_rating = max(reduce(max, rater_a), reduce(max, rater_b))
+        max_rating = max(rater_a + rater_b)
     num_ratings = max_rating - min_rating + 1
     conf_mat = [[0 for i in range(num_ratings)]
                 for j in range(num_ratings)]
-    for a,b in zip(rater_a,rater_b):
-        conf_mat[a-min_rating][b-min_rating] += 1
+    for a, b in zip(rater_a, rater_b):
+        conf_mat[a - min_rating][b - min_rating] += 1
     return conf_mat
 
 def histogram(ratings, min_rating=None, max_rating=None):
     """
     Returns the counts of each type of rating that a rater made
     """
-    if min_rating is None: min_rating = reduce(min, ratings)
-    if max_rating is None: max_rating = reduce(max, ratings)
+    if min_rating is None:
+        min_rating = min(ratings)
+    if max_rating is None:
+        max_rating = max(ratings)
     num_ratings = max_rating - min_rating + 1
     hist_ratings = [0 for x in range(num_ratings)]
     for r in ratings:
-	    hist_ratings[r-min_rating] += 1
+        hist_ratings[r - min_rating] += 1
     return hist_ratings
 
-def quadratic_weighted_kappa(rater_a, rater_b,
-                             min_rating = None, max_rating = None):
+def quadratic_weighted_kappa(rater_a, rater_b, min_rating = None, max_rating = None):
     """
     Calculates the quadratic weighted kappa
     quadratic_weighted_kappa calculates the quadratic weighted kappa
     value, which is a measure of inter-rater agreement between two raters
-    that provide discrete numeric ratings.  Potential values range from -1  
+    that provide discrete numeric ratings.  Potential values range from -1
     (representing complete disagreement) to 1 (representing complete
     agreement).  A kappa value of 0 is expected if all agreement is due to
     chance.
-    
+
     quadratic_weighted_kappa(rater_a, rater_b), where rater_a and rater_b
     each correspond to a list of integer ratings.  These lists must have the
     same length.
-    
+
     The ratings should be integers, and it is assumed that they contain
     the complete range of possible ratings.
-   
+
     quadratic_weighted_kappa(X, min_rating, max_rating), where min_rating
     is the minimum possible rating, and max_rating is the maximum possible
     rating
     """
     assert(len(rater_a) == len(rater_b))
     if min_rating is None:
-	min_rating = min(reduce(min, rater_a), reduce(min, rater_b))
+        min_rating = min(rater_a + rater_b)
     if max_rating is None:
-	max_rating = max(reduce(max, rater_a), reduce(max, rater_b))
+        max_rating = max(rater_a + rater_b)
     conf_mat = confusion_matrix(rater_a, rater_b,
-				     min_rating, max_rating)
+                                     min_rating, max_rating)
     num_ratings = len(conf_mat)
     num_scored_items = float(len(rater_a))
 
@@ -70,44 +70,43 @@ def quadratic_weighted_kappa(rater_a, rater_b,
     denominator = 0.0
 
     for i in range(num_ratings):
-	for j in range(num_ratings):
-	    expected_count = (hist_rater_a[i]*hist_rater_b[j]
-			      / num_scored_items) 
-	    d = pow(i-j,2.0) / pow(num_ratings-1, 2.0)
-	    numerator += d*conf_mat[i][j] / num_scored_items
-	    denominator += d*expected_count / num_scored_items
+        for j in range(num_ratings):
+            expected_count = (hist_rater_a[i] * hist_rater_b[j]
+                              / num_scored_items)
+            d = pow(i - j, 2.0) / pow(num_ratings - 1, 2.0)
+            numerator += d * conf_mat[i][j] / num_scored_items
+            denominator += d * expected_count / num_scored_items
 
     return 1.0 - numerator / denominator
 
-def linear_weighted_kappa(rater_a, rater_b,
-                             min_rating = None, max_rating = None):
+def linear_weighted_kappa(rater_a, rater_b, min_rating = None, max_rating = None):
     """
     Calculates the linear weighted kappa
     linear_weighted_kappa calculates the linear weighted kappa
     value, which is a measure of inter-rater agreement between two raters
-    that provide discrete numeric ratings.  Potential values range from -1  
+    that provide discrete numeric ratings.  Potential values range from -1
     (representing complete disagreement) to 1 (representing complete
     agreement).  A kappa value of 0 is expected if all agreement is due to
     chance.
-    
+
     linear_weighted_kappa(rater_a, rater_b), where rater_a and rater_b
     each correspond to a list of integer ratings.  These lists must have the
     same length.
-    
+
     The ratings should be integers, and it is assumed that they contain
     the complete range of possible ratings.
-   
+
     linear_weighted_kappa(X, min_rating, max_rating), where min_rating
     is the minimum possible rating, and max_rating is the maximum possible
     rating
     """
     assert(len(rater_a) == len(rater_b))
     if min_rating is None:
-	min_rating = min(reduce(min, rater_a), reduce(min, rater_b))
+        min_rating = min(rater_a + rater_b)
     if max_rating is None:
-	max_rating = max(reduce(max, rater_a), reduce(max, rater_b))
+        max_rating = max(rater_a + rater_b)
     conf_mat = confusion_matrix(rater_a, rater_b,
-				     min_rating, max_rating)
+                                     min_rating, max_rating)
     num_ratings = len(conf_mat)
     num_scored_items = float(len(rater_a))
 
@@ -118,44 +117,43 @@ def linear_weighted_kappa(rater_a, rater_b,
     denominator = 0.0
 
     for i in range(num_ratings):
-	for j in range(num_ratings):
-	    expected_count = (hist_rater_a[i]*hist_rater_b[j]
-			      / num_scored_items) 
-	    d = abs(i-j) / float(num_ratings-1)
-	    numerator += d*conf_mat[i][j] / num_scored_items
-	    denominator += d*expected_count / num_scored_items
+        for j in range(num_ratings):
+            expected_count = (hist_rater_a[i] * hist_rater_b[j]
+                              / num_scored_items)
+            d = abs(i - j) / float(num_ratings - 1)
+            numerator += d * conf_mat[i][j] / num_scored_items
+            denominator += d * expected_count / num_scored_items
 
     return 1.0 - numerator / denominator
 
-def kappa(rater_a, rater_b,
-                             min_rating = None, max_rating = None):
+def kappa(rater_a, rater_b, min_rating = None, max_rating = None):
     """
     Calculates the kappa
     kappa calculates the kappa
     value, which is a measure of inter-rater agreement between two raters
-    that provide discrete numeric ratings.  Potential values range from -1  
+    that provide discrete numeric ratings.  Potential values range from -1
     (representing complete disagreement) to 1 (representing complete
     agreement).  A kappa value of 0 is expected if all agreement is due to
     chance.
-    
+
     kappa(rater_a, rater_b), where rater_a and rater_b
     each correspond to a list of integer ratings.  These lists must have the
     same length.
-    
+
     The ratings should be integers, and it is assumed that they contain
     the complete range of possible ratings.
-   
+
     kappa(X, min_rating, max_rating), where min_rating
     is the minimum possible rating, and max_rating is the maximum possible
     rating
     """
     assert(len(rater_a) == len(rater_b))
     if min_rating is None:
-	min_rating = min(reduce(min, rater_a), reduce(min, rater_b))
+        min_rating = min(rater_a + rater_b)
     if max_rating is None:
-	max_rating = max(reduce(max, rater_a), reduce(max, rater_b))
+        max_rating = max(rater_a + rater_b)
     conf_mat = confusion_matrix(rater_a, rater_b,
-				     min_rating, max_rating)
+                                     min_rating, max_rating)
     num_ratings = len(conf_mat)
     num_scored_items = float(len(rater_a))
 
@@ -166,15 +164,15 @@ def kappa(rater_a, rater_b,
     denominator = 0.0
 
     for i in range(num_ratings):
-	for j in range(num_ratings):
-	    expected_count = (hist_rater_a[i]*hist_rater_b[j]
-			      / num_scored_items) 
-	    if i==j:
-	        d=0.0
-	    else:
-	        d=1.0
-	    numerator += d*conf_mat[i][j] / num_scored_items
-	    denominator += d*expected_count / num_scored_items
+        for j in range(num_ratings):
+            expected_count = (hist_rater_a[i] * hist_rater_b[j]
+                              / num_scored_items)
+            if i == j:
+                d = 0.0
+            else:
+                d = 1.0
+            numerator += d * conf_mat[i][j] / num_scored_items
+            denominator += d * expected_count / num_scored_items
 
     return 1.0 - numerator / denominator
 
@@ -186,7 +184,7 @@ def mean_quadratic_weighted_kappa(kappas, weights=None):
     transformation is undefined if one of the kappas is 1.0, so all kappa
     values are capped in the range (-0.999, 0.999).  The reverse
     transformation is then applied before returning the result.
-    
+
     mean_quadratic_weighted_kappa(kappas), where kappas is a vector of
     kappa values
 
@@ -203,8 +201,7 @@ def mean_quadratic_weighted_kappa(kappas, weights=None):
     # ensure that kappas are in the range [-.999, .999]
     kappas = numpy.array([min(x, .999) for x in kappas])
     kappas = numpy.array([max(x, -.999) for x in kappas])
-    
-    z = 0.5 * numpy.log( (1+kappas)/(1-kappas) ) * weights
+
+    z = 0.5 * numpy.log((1 + kappas) / (1 - kappas)) * weights
     z = numpy.mean(z)
-    kappa = (numpy.exp(2*z)-1) / (numpy.exp(2*z)+1)
-    return kappa
+    return (numpy.exp(2 * z) - 1) / (numpy.exp(2 * z) + 1)


### PR DESCRIPTION
min supports lists directly, so reduce(min, rater_a) was verbose (and potentially less efficient).

I also improved the PEP8 compliance by getting rid of TABs used for indentation and adding spaces around operators.
