### PR TITLE
Bumped up version number in setup.py to make pip install latest version with Python 3 fixes.

### DIFF
--- a/Python/setup.py
+++ b/Python/setup.py
@@ -11,7 +11,7 @@ if sys.version_info >= (3,):
     extra['use_2to3'] = True
 
 setup(name='ml_metrics',
-      version='0.1.2',
+      version='0.1.3',
       description='Machine Learning Evaluation Metrics',
       author = 'Ben Hamner',
       author_email = 'ben@benhamner.com',


### PR DESCRIPTION
Currently, the Python ml_metrics package on PyPI is not Python 3 compatible because it is out-of-date. I've bumped the version number up to avoid any conflicts, so if you could please run "python setup.py register" and "python setup.py sdist upload" so this latest version gets up there, that would be extremely helpful.

We at ETS have recently released a ML package, SciKit-Learn Laboratory (SKLL) that relies on ml_metrics for kappa, and we don't want to have to repackage your code with ours unless absolutely necessary.
