### PR TITLE
Update metrics. R

### DIFF
--- a/R/R/metrics.r
+++ b/R/R/metrics.r
@@ -260,7 +260,8 @@ ScoreQuadraticWeightedKappa <- function (rater.a , rater.b,
     weights <- outer(labels, labels, FUN <- function(x,y) (x-y)^2 )
 
     #calculate kappa
-    kappa <- 1 - sum(weights*confusion.mat)/sum(weights*expected.mat)
+    # kappa <- 1 - sum(weights*confusion.mat)/sum(weights*expected.mat)
+    kappa = ifelse(sum(weights*expected.mat) == 0, 1, 1 - sum(weights*confusion.mat)/sum(weights*expected.mat))
     kappa
 }
 


### PR DESCRIPTION
Corrected rare case, where metrics fails and gives "NaN"..
Happens in case of perfect match and  both expected.mat and confusion.mat only have one nonzero entry.
(Example where the metric fails:
rater.a = c(2, 2, 2, 2, 2, 2)
rater.b = c(2, 2, 2, 2, 2, 2))
Help by Stephen McInerney   in Kaggle forum