### PR TITLE
Update metrics.r

### DIFF
--- a/R/R/metrics.r
+++ b/R/R/metrics.r
@@ -121,7 +121,7 @@ rae <- function (actual, predicted)
 auc <- function(actual, predicted)
 {
     r <- rank(predicted)
-    n_pos <- sum(actual==1)
+    n_pos <- as.numeric(sum(actual==1))
     n_neg <- length(actual) - n_pos
     auc <- (sum(r[actual==1]) - n_pos*(n_pos+1)/2) / (n_pos*n_neg)
     auc


### PR DESCRIPTION
Without as.numeric()  n_pos*n_neg  later leads to integer overflow on the big datasets
