### PR TITLE
in apk, avoid error when length of `actual` > 1

### DIFF
--- a/Python/ml_metrics/average_precision.py
+++ b/Python/ml_metrics/average_precision.py
@@ -33,7 +33,7 @@ def apk(actual, predicted, k=10):
             num_hits += 1.0
             score += num_hits / (i+1.0)
 
-    if not actual:
+    if not len(actual):
         return 0.0
 
     return score / min(len(actual), k)


### PR DESCRIPTION
Evaluating `not actual` results in error when len(actual) > 1, `not len(actual)` returns 0 when length of `actual` is 0 while accomodating len(actual) > 1
