### PR TITLE
ap@k in R should work even if one of the vectors is empty

### DIFF
--- a/R/R/metrics.r
+++ b/R/R/metrics.r
@@ -164,6 +164,11 @@ logLoss <- function(actual, predicted) mean(ll(actual, predicted))
 #' @export
 apk <- function(k, actual, predicted)
 {
+    if (length(actual) == 0 || length(predicted) == 0) 
+    {
+        return(0.0)
+    }
+
     score <- 0.0
     cnt <- 0.0
     for (i in 1:min(k,length(predicted)))

--- a/R/inst/tests/test-apk.r
+++ b/R/inst/tests/test-apk.r
@@ -6,6 +6,9 @@ test.apk <- function()
     checkEqualsNumeric(apk(3, c(1,3), 1:5), 5/6)
     checkEqualsNumeric(apk(3, 1:3, c(1,1,1)), 1/3)
     checkEqualsNumeric(apk(3, 1:3, c(1,2,1)), 2/3)    
+    checkEqualsNumeric(apk(3, 1:3, numeric(0)), 0.0)
+    checkEqualsNumeric(apk(3, numeric(0), 1:3), 0.0)
+    checkEqualsNumeric(apk(3, numeric(0), numeric(0)), 0.0)
 }
 
 test.mapk <- function()
@@ -15,5 +18,5 @@ test.mapk <- function()
     checkEqualsNumeric(mapk(3, list(c(1,3,4),c(1,2,4),c(1,3)), list(1:5,1:5,1:5)), 0.685185185185185)
     checkEqualsNumeric(mapk(5, list(1:5,1:5), list(c(6,4,7,1,2),c(1,1,1,1,1))), 0.26)
     checkEqualsNumeric(mapk(3, list(c(1,3),1:3,1:3), list(1:5,c(1,1,1),c(1,2,1))), 11/18)
-
+    checkEqualsNumeric(mapk(3, list(), list()), 0.0)
 }


### PR DESCRIPTION
I came across this problem when I tried to use ap@k for a recommendation system that returns no items if the confidence is low.