### PR TITLE
Refactor auc to avoid multiplication

### DIFF
--- a/R/R/metrics.r
+++ b/R/R/metrics.r
@@ -123,7 +123,7 @@ auc <- function(actual, predicted)
     r <- rank(predicted)
     n_pos <- sum(actual==1)
     n_neg <- length(actual) - n_pos
-    auc <- (sum(r[actual==1]) - n_pos*(n_pos+1)/2) / (n_pos*n_neg)
+    auc <- sum(r[actual==1])/n_pos/n_neg - (n_pos+1)/2/n_neg
     auc
 }
 


### PR DESCRIPTION
Multiplying n_pos and n_neg can result in integer overflow. A little algebraic manipulation can avoid the multiplication, removing the possibility of overflow.