### PR TITLE
Fix average precision at k calculation

### DIFF
--- a/Python/ml_metrics/average_precision.py
+++ b/Python/ml_metrics/average_precision.py
@@ -1,48 +1,47 @@
 import numpy as np
 
-def apk(actual, predicted, k=10):
+
+def apk(actual: list, predicted: list, k=10) -> float:
     """
     Computes the average precision at k.
-
-    This function computes the average prescision at k between two lists of
+    This function computes the average precision at k between two lists of
     items.
-
     Parameters
     ----------
     actual : list
-             A list of elements that are to be predicted (order doesn't matter)
+             A list of elements that are to be predicted
     predicted : list
-                A list of predicted elements (order does matter)
+             A list of predicted elements (order does matter)
     k : int, optional
         The maximum number of predicted elements
-
     Returns
     -------
-    score : double
+    score : float
             The average precision at k over the input lists
-
     """
-    if len(predicted)>k:
+    if len(predicted) > k:
         predicted = predicted[:k]
 
-    score = 0.0
+    sum_precision = 0.0
     num_hits = 0.0
 
-    for i,p in enumerate(predicted):
-        if p in actual and p not in predicted[:i]:
+    for i, prediction in enumerate(predicted):
+        if prediction in actual[:k] and prediction not in predicted[:i]:
             num_hits += 1.0
-            score += num_hits / (i+1.0)
+            precision_at_i = num_hits / (i + 1.0)
+            sum_precision += precision_at_i
 
-    if not actual:
+    if num_hits == 0.0:
         return 0.0
 
-    return score / min(len(actual), k)
+    return sum_precision / num_hits
 
-def mapk(actual, predicted, k=10):
+
+def mapk(actual: list, predicted: list, k=10) -> float:
     """
     Computes the mean average precision at k.
 
-    This function computes the mean average prescision at k between two lists
+    This function computes the mean average precision at k between two lists
     of lists of items.
 
     Parameters
@@ -62,4 +61,4 @@ def mapk(actual, predicted, k=10):
             The mean average precision at k over the input lists
 
     """
-    return np.mean([apk(a,p,k) for a,p in zip(actual, predicted)])
+    return np.mean([apk(a, p, k) for a, p in zip(actual, predicted)])


### PR DESCRIPTION
This PR fixes #49 
According to the [Wikipedia page of Average Precision](https://en.wikipedia.org/wiki/Evaluation_measures_(information_retrieval)#Average_precision) the equation is defined as follow:
![image](https://user-images.githubusercontent.com/20357405/117638956-af9bfd80-b183-11eb-84e1-381273aa4046.png)
where `rel(k)`  is an indicator function equaling 1 if the item at rank `k` is a relevant document, zero otherwise. Note that the average is over all relevant documents, and the relevant documents not retrieved get a precision score of zero.
Before, the average was calculated over the minimum value between the length of the actual value and `k`. This doesn't seem right since the length of the actual list of `k` increases; the AP@K will decrease.
I fixed and cleaned up the code. Please consider merging this! This could lead to many mistakes.