### PR TITLE
Solution for installation errors

### DIFF
--- a/Python/README.md
+++ b/Python/README.md
@@ -3,7 +3,11 @@
 Installation
 ============
 
-To install from PyPI,
+To install from PyPI, you need setuptools<58.0 . 
+
+```
+pip install setuptools<58.0
+```
 
 ```
 pip install ml_metrics

--- a/Python/requirements.txt
+++ b/Python/requirements.txt
@@ -1,2 +1,3 @@
 numpy
 pandas
+setuptools<58.0

--- a/Python/setup.py
+++ b/Python/setup.py
@@ -5,7 +5,8 @@ import sys
 
 requirements = [
 	"numpy", 
-	"pandas"
+	"pandas",
+	"setuptools<58.0"
 	]
 
 # Automatically run 2to3 for Python 3 support


### PR DESCRIPTION
* We get this error when we try to install ml_metrics through pip

```
pip install ml_metrics
Collecting ml_metrics
  Downloading ml_metrics-0.1.4.tar.gz (5.0 kB)
  Preparing metadata (setup.py) ... error
  error: subprocess-exited-with-error
  
  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [1 lines of output]
      error in ml_metrics setup command: use_2to3 is invalid.
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> See above for output.

note: This is an issue with the package mentioned above, not pip.
hint: See above for details.
```
* An easy solution have been added in the README.md file .

* We will face the following error when we try to install it from source (Following the instruction given in README of Python.

```
it clone https://github.com/benhamner/Metrics.git
cd Metrics/Python
python setup.py install
Cloning into 'Metrics'...
remote: Enumerating objects: 1192, done.
remote: Total 1192 (delta 0), reused 0 (delta 0), pack-reused 1192
Receiving objects: 100% (1192/1192), 329.79 KiB | 715.00 KiB/s, done.
Resolving deltas: 100% (480/480), done.
error in ml_metrics setup command: use_2to3 is invalid.
```
* Have added the solution in the Setup.py file.